### PR TITLE
Fix set Swift Version in Podspec file

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
     ss.osx.deployment_target = '10.10'
     ss.watchos.deployment_target = '2.0'
     ss.tvos.deployment_target = '9.0'
+	ss.xcconfig = { 'SWIFT_VERSION' => '3.0' }
     ss.source_files = 'Classes/CocoaLumberjack.swift'
     ss.dependency 'CocoaLumberjack/Extensions'
   end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 
If you update to Swift 3 without declaring it in the podspec , you'll need to manually change it after every pod install or set it with a post installer

```
post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['SWIFT_VERSION'] = '3.0'
    end
  end
end
```

### Pull Request Description
This PR is basically the PR #769 that you already sent, with the additional setting in the podspec
